### PR TITLE
Use latest tag for Java and Node.js images

### DIFF
--- a/apm-agent-auto-attach/values.yaml
+++ b/apm-agent-auto-attach/values.yaml
@@ -26,12 +26,12 @@ podLabels: {}
 webhookConfig:
   agents:
     java:
-      image: docker.elastic.co/observability/apm-agent-java:1.30.1
+      image: docker.elastic.co/observability/apm-agent-java:latest
       artifact: "/usr/agent/elastic-apm-agent.jar"
       environment:
         JAVA_TOOL_OPTIONS: "-javaagent:/elastic/apm/agent/elastic-apm-agent.jar"
     nodejs:
-      image: docker.elastic.co/observability/apm-agent-nodejs:3.34.0
+      image: docker.elastic.co/observability/apm-agent-nodejs:latest
       artifact: "/usr/agent/nodejs/node_modules/elastic-apm-node"
       environment:
         NODE_OPTIONS: "-r /elastic/apm/agent/elastic-apm-node/start"


### PR DESCRIPTION
As of just now, we now have the `latest` tag available for both the Node.js and Java agents. Let's use the `latest` tag to avoid the versions becoming stale.