### PR TITLE
Update apm-mutating-webhook.asciidoc

### DIFF
--- a/docs/apm-mutating-webhook.asciidoc
+++ b/docs/apm-mutating-webhook.asciidoc
@@ -27,7 +27,6 @@ Supported agents include:
 // links will be added later
 * Java agent
 * Node.js agent
-* .NET agent
 
 The webhook receiver is invoked on pod creation. After receiving the object definition from the Kubernetes
 API server, it looks through the pod spec for a specific, user-supplied annotation. If found, the pod spec

--- a/docs/apm-mutating-webhook.asciidoc
+++ b/docs/apm-mutating-webhook.asciidoc
@@ -7,8 +7,6 @@
 [[apm-attacher]]
 == APM Attacher
 
-preview::[]
-
 The APM attacher for Kubernetes simplifies the instrumentation and configuration of your application pods.
 
 The attacher includes a <<apm-webhook,webhook receiver>> that modifies pods so they are automatically
@@ -27,6 +25,7 @@ Supported agents include:
 // links will be added later
 * Java agent
 * Node.js agent
+* preview:[] .NET agent
 
 The webhook receiver is invoked on pod creation. After receiving the object definition from the Kubernetes
 API server, it looks through the pod spec for a specific, user-supplied annotation. If found, the pod spec

--- a/docs/apm-mutating-webhook.asciidoc
+++ b/docs/apm-mutating-webhook.asciidoc
@@ -23,9 +23,9 @@ The webhook receiver modifies pods so they are automatically instrumented by an 
 Supported agents include:
 
 // links will be added later
-* Java agent
-* Node.js agent
-* preview:[] .NET agent
+* {apm-java-ref-v}/intro.html[Java agent]
+* {apm-node-ref-v}/intro.html[Node.js agent]
+* preview:[] {apm-dotnet-ref-v}/intro.html[.NET agent]
 
 The webhook receiver is invoked on pod creation. After receiving the object definition from the Kubernetes
 API server, it looks through the pod spec for a specific, user-supplied annotation. If found, the pod spec


### PR DESCRIPTION
The .NET attacher is not GA and won't be until after 8.12.

I'm not sure if the "tech preview" message at the top will be removed for 8.12. If so, then we should mark only the .NET attacher as tech preview.