### PR TITLE
Remove support for the legacy annotation (co.elastic.traces/agent)

### DIFF
--- a/main.go
+++ b/main.go
@@ -180,10 +180,7 @@ func (s *server) mutate(admReview *admissionv1.AdmissionReview) error {
 	return nil
 }
 
-const (
-	apmAnnotation       = "co.elastic.apm/attach"
-	legacyAPMAnnotation = "co.elastic.traces/agent"
-)
+const apmAnnotation = "co.elastic.apm/attach"
 
 func getConfig(configs map[string]agentConfig, annotations map[string]string) (agentConfig, error) {
 	ac := agentConfig{}
@@ -193,9 +190,7 @@ func getConfig(configs map[string]agentConfig, annotations map[string]string) (a
 	// TODO: Do we want to support multiple comma-separated agents?
 	agent, ok := annotations[apmAnnotation]
 	if !ok {
-		if agent, ok = annotations[legacyAPMAnnotation]; !ok {
-			return ac, errors.New("missing annotation `co.elastic.apm/attach`")
-		}
+		return ac, fmt.Errorf("missing annotation `%s`", apmAnnotation)
 	}
 	// TODO: validate the config has a container field
 	config, ok := configs[agent]

--- a/main_test.go
+++ b/main_test.go
@@ -62,16 +62,6 @@ func TestGetConfig(t *testing.T) {
 		"dotnet": {Image: "dotnet-image"},
 	}
 	for _, agentName := range []string{"nodejs", "java", "dotnet"} {
-		t.Run(fmt.Sprint("legacy annotation", agentName), func(t *testing.T) {
-			config, err := getConfig(configs, map[string]string{
-				legacyAPMAnnotation: agentName,
-			})
-			assert.NoError(t, err)
-			assert.Equal(t, agentConfig{
-				Image: fmt.Sprint(agentName, "-image"),
-			}, config)
-		})
-
 		t.Run("supported annotation", func(t *testing.T) {
 			config, err := getConfig(configs, map[string]string{
 				apmAnnotation: agentName,


### PR DESCRIPTION
Only the 'co.elastic.apm/attach' annotation is supported now.

---

Per suggestion at https://github.com/elastic/apm-k8s-attacher/issues/28#issuecomment-1893169715