### PR TITLE
docs: remove 'this is tech preview' marker on one of the attacher guide pages

### DIFF
--- a/docs/apm-k8s-attacher.asciidoc
+++ b/docs/apm-k8s-attacher.asciidoc
@@ -62,8 +62,6 @@ TIP: To learn more about Helm charts, see the {helm-docs}[Helm documentation].
 [[apm-get-started-webhook]]
 == Instrument and configure pods
 
-preview::[]
-
 To instrument and configure your application pods, complete the following steps:
 
 . <<apm-webhook-add-helm-repo>>


### PR DESCRIPTION
This is a follow-up to #85. This attacher is GA now.
