### PR TITLE
feat: migrate to chainguard images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
 ARG GO_VERSION=1.24
 FROM golang:${GO_VERSION}-alpine AS build
-RUN apk update
-RUN apk upgrade
 ADD *go* /app/
 WORKDIR /app
-RUN CGO_ENABLED=0 go build -o webhook -a -installsuffix cgo .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s" -o webhook .
 
-FROM alpine
+FROM cgr.dev/chainguard/static:latest@sha256:853bfd4495abb4b65ede8fc9332513ca2626235589c2cef59b4fce5082d0836d
 WORKDIR /usr/share/apm-k8s-attacher
 COPY --from=build /app/webhook .
 ADD LICENSE.txt NOTICE.txt /usr/share/apm-k8s-attacher/


### PR DESCRIPTION
drop debug information and make the image more reproducible

image size went from 22Mb to 11Mb