### PR TITLE
bump golang to 1.24.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/apm-k8s-attacher
 
-go 1.24.0
+go 1.24.2
 
 require (
 	github.com/stretchr/testify v1.10.0


### PR DESCRIPTION
Bump Golang to latest 1.24.2
