### PR TITLE
scope write permissions to jobs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,11 +7,13 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
 
 jobs:
   triage:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: AlexanderWert/issue-labeler@v2.3


### PR DESCRIPTION
Restores the job-level permissions structure in labeler.yml from #186 (commit 54574cd), which was reverted by Copilot's merge-conflict resolution before that PR merged: top-level stays read-only, `issues: write` / `pull-requests: write` move to the `triage` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)